### PR TITLE
Make codecov links https to avoid the yellow triangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/invenia/Nabla.jl.svg?branch=master)](https://travis-ci.org/invenia/Nabla.jl)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/g0gun5dxbkt631am/branch/master?svg=true)](https://ci.appveyor.com/project/iamed2/nabla-jl/branch/master)
-[![codecov.io](http://codecov.io/github/invenia/Nabla.jl/coverage.svg?branch=master)](http://codecov.io/github/invenia/Nabla.jl?branch=master)
+[![codecov.io](https://codecov.io/github/invenia/Nabla.jl/coverage.svg?branch=master)](https://codecov.io/github/invenia/Nabla.jl?branch=master)
 [![Stable Docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/Nabla.jl/stable)
 [![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/Nabla.jl/latest)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/invenia/Nabla.jl.svg?branch=master)](https://travis-ci.org/invenia/Nabla.jl)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/g0gun5dxbkt631am/branch/master?svg=true)](https://ci.appveyor.com/project/iamed2/nabla-jl/branch/master)
-[![codecov.io](http://codecov.io/github/invenia/Nabla.jl/coverage.svg?branch=master)](http://codecov.io/github/invenia/Nabla.jl?branch=master)
+[![codecov.io](https://codecov.io/github/invenia/Nabla.jl/coverage.svg?branch=master)](https://codecov.io/github/invenia/Nabla.jl?branch=master)
 [![Stable Docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/Nabla.jl/stable)
 [![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/Nabla.jl/latest)
 


### PR DESCRIPTION
We previously had a warning that the page was not secure because of this. A very minor thing.