### PR TITLE
Diagm implementation

### DIFF
--- a/src/sensitivities/linalg/diagonal.jl
+++ b/src/sensitivities/linalg/diagonal.jl
@@ -10,7 +10,7 @@ function ∇(
     p,
     Y::∇AbstractMatrix,
     Ȳ::∇AbstractMatrix,
-    x::∇AbstractVector
+    x::∇AbstractVector,
 )
     return copy!(similar(x), view(Ȳ, diagind(Ȳ)))
 end
@@ -21,9 +21,22 @@ function ∇(
     p,
     Y::∇AbstractMatrix,
     Ȳ::∇AbstractMatrix,
-    x::∇AbstractVector
+    x::∇AbstractVector,
 )
     return broadcast!(+, x̄, x̄, view(Ȳ, diagind(Ȳ)))
+end
+
+@explicit_intercepts diagm Tuple{∇Scalar}
+function ∇(
+    ::typeof(diagm),
+    ::Type{Arg{1}},
+    p,
+    Y::∇AbstractMatrix,
+    Ȳ::∇AbstractMatrix,
+    x::∇Scalar,
+)
+    length(Ȳ) != 1 && throw(error("Ȳ isn't a 1x1 matrix."))
+    return Ȳ[1]
 end
 
 @explicit_intercepts Diagonal Tuple{∇AbstractVector}
@@ -33,7 +46,7 @@ function ∇(
     p,
     Y::∇ScalarDiag,
     Ȳ::∇ScalarDiag,
-    x::∇AbstractVector
+    x::∇AbstractVector,
 )
     return copy!(similar(x), Ȳ.diag)
 end
@@ -44,7 +57,7 @@ function ∇(
     p,
     Y::∇ScalarDiag,
     Ȳ::∇ScalarDiag,
-    x::∇AbstractVector
+    x::∇AbstractVector,
 )
     return broadcast!(+, x̄, x̄, Ȳ.diag)
 end
@@ -56,7 +69,7 @@ function ∇(
     p,
     Y::∇ScalarDiag,
     Ȳ::∇ScalarDiag,
-    X::∇AbstractMatrix
+    X::∇AbstractMatrix,
 )
     X̄ = zeros(X)
     copy!(view(X̄, diagind(X)), Ȳ.diag)
@@ -69,7 +82,7 @@ function ∇(
     p,
     Y::∇ScalarDiag,
     Ȳ::∇ScalarDiag,
-    X::∇AbstractMatrix
+    X::∇AbstractMatrix,
 )
     X̄_diag = view(X̄, diagind(X̄))
     broadcast!(+, X̄_diag, X̄_diag, Ȳ.diag)
@@ -86,7 +99,7 @@ function ∇(
     p,
     y::∇Scalar,
     ȳ::∇Scalar,
-    X::∇ScalarDiag
+    X::∇ScalarDiag,
 )
     broadcast!((x̄, x, y, ȳ)->x̄ + ȳ * y / x, X̄.diag, X̄.diag, X.diag, y, ȳ)
     return X̄

--- a/src/sensitivities/linalg/diagonal.jl
+++ b/src/sensitivities/linalg/diagonal.jl
@@ -3,7 +3,7 @@ export diagm, Diagonal
 
 const ∇ScalarDiag = Diagonal{<:∇Scalar}
 
-@explicit_intercepts diagm Tuple{∇AbstractVector}
+@explicit_intercepts diagm Tuple{∇AbstractVector} 
 function ∇(
     ::typeof(diagm),
     ::Type{Arg{1}},
@@ -24,6 +24,31 @@ function ∇(
     x::∇AbstractVector,
 )
     return broadcast!(+, x̄, x̄, view(Ȳ, diagind(Ȳ)))
+end
+
+@explicit_intercepts diagm Tuple{∇AbstractVector, Integer} [true, false]
+function ∇(
+    ::typeof(diagm),
+    ::Type{Arg{1}},
+    p,
+    Y::∇AbstractMatrix,
+    Ȳ::∇AbstractMatrix,
+    x::∇AbstractVector,
+    k::Integer,
+)
+    return copy!(similar(x), view(Ȳ, diagind(Ȳ, k)))
+end
+function ∇(
+    x̄::∇AbstractVector,
+    ::typeof(diagm),
+    ::Type{Arg{1}},
+    p,
+    Y::∇AbstractMatrix,
+    Ȳ::∇AbstractMatrix,
+    x::∇AbstractVector,
+    k::Integer,
+)
+    return broadcast!(+, x̄, x̄, view(Ȳ, diagind(Ȳ, k)))
 end
 
 @explicit_intercepts diagm Tuple{∇Scalar}

--- a/test/sensitivities/linalg/diagonal.jl
+++ b/test/sensitivities/linalg/diagonal.jl
@@ -3,6 +3,8 @@
         for _ in 1:10
             x, vx = randn.(rng, [N, N])
             @test check_errs(diagm, diagm(randn(rng, N)), x, vx)
+            x, vx = randn(rng), randn(rng)
+            @test check_errs(diagm, diagm(randn(rng)), x, vx)
         end
     end
     let rng = MersenneTwister(123456), N = 10

--- a/test/sensitivities/linalg/diagonal.jl
+++ b/test/sensitivities/linalg/diagonal.jl
@@ -1,8 +1,23 @@
 @testset "Diagonal" begin
     let rng = MersenneTwister(123456), N = 10
+        λ_2 = x->diagm(x, 2)
+        λ_m3 = x->diagm(x, -3)
+        λ_0 = x->diagm(x, 0)
+        λ_false = x->diagm(x, false)
+        λ_true = x->diagm(x, true)
         for _ in 1:10
+
+            # Test vector case.
             x, vx = randn.(rng, [N, N])
             @test check_errs(diagm, diagm(randn(rng, N)), x, vx)
+
+            @test check_errs(λ_2, λ_2(randn(rng, N)), x, vx)
+            @test check_errs(λ_m3, λ_m3(randn(rng, N)), x, vx)
+            @test check_errs(λ_0, λ_0(randn(rng, N)), x, vx)
+            @test check_errs(λ_false, λ_false(randn(rng, N)), x, vx)
+            @test check_errs(λ_true, λ_true(randn(rng, N)), x, vx)
+
+            # Test scalar case.
             x, vx = randn(rng), randn(rng)
             @test check_errs(diagm, diagm(randn(rng)), x, vx)
         end


### PR DESCRIPTION
This adds two new pieces of functionality. The first is support for `diagm` with a scalar argument, which fixes #64. The second is support for the two-argument form of `diagm`, so that we can handle matrices which are off-diagonal.