### PR TITLE
Optimising det and logdet for triangular matrices

### DIFF
--- a/src/finite_differencing.jl
+++ b/src/finite_differencing.jl
@@ -104,7 +104,8 @@ function check_approx_equal(desc, x, y, ε_abs, ε_rel)
               "  relative error:  $(@sprintf "%.3e" abs(x - y) / (abs(x) + abs(y)))\n" *
               "    tolerance:     $(@sprintf "%.3e" ε_rel)\n" *
               "  absolute error:  $(@sprintf "%.3e" abs(x - y))\n" *
-              "    tolerance:     $(@sprintf "%.3e" ε_abs)"
+              "    tolerance:     $(@sprintf "%.3e" ε_abs)\n" *
+              "  input:           $(@sprintf "%.3e" x)"
         throw(ErrorException(msg))
     end
     return true

--- a/src/finite_differencing.jl
+++ b/src/finite_differencing.jl
@@ -104,8 +104,7 @@ function check_approx_equal(desc, x, y, ε_abs, ε_rel)
               "  relative error:  $(@sprintf "%.3e" abs(x - y) / (abs(x) + abs(y)))\n" *
               "    tolerance:     $(@sprintf "%.3e" ε_rel)\n" *
               "  absolute error:  $(@sprintf "%.3e" abs(x - y))\n" *
-              "    tolerance:     $(@sprintf "%.3e" ε_abs)\n" *
-              "  input:           $(@sprintf "%.3e" x)"
+              "    tolerance:     $(@sprintf "%.3e" ε_abs)\n"
         throw(ErrorException(msg))
     end
     return true
@@ -347,3 +346,4 @@ end
 # error, strangely enough.
 domain2(::typeof(beta)) = Nullable(((minimum(points[points .> 0]), maximum(points)),
                                     (minimum(points[points .> 0]), maximum(points))))
+domain1(::typeof(gamma)) = Nullable((minimum(points[points .> 0]), maximum(points[points .> 0])))

--- a/src/sensitivities/functional/functional.jl
+++ b/src/sensitivities/functional/functional.jl
@@ -44,7 +44,7 @@ end
 Allocating version of broadcastsum! specialised for Arrays.
 """
 broadcastsum(f::Function, add::Bool, z::AbstractArray, As...) =
-    broadcastsum!(f, add, similar(z), As...)
+    broadcastsum!(f, add, Array{eltype(z)}(size(z)), As...)
 
 """
     broadcastsum(f::Function, add::Bool, z::Number, As...)

--- a/src/sensitivities/functional/reduce.jl
+++ b/src/sensitivities/functional/reduce.jl
@@ -7,17 +7,8 @@ for (f, base_f_name) in ((:mapreduce, :(Base.mapreduce)),
                               (:mapfoldr, :(Base.mapfoldr)))
     @eval import Base.$f
     @eval @explicit_intercepts $f $type_tuple [false, false, true]
-    @eval function ∇(
-        ::typeof($f),
-        ::Type{Arg{3}},
-        p, y, ȳ, f,
-        ::typeof(+),
-        A::AbstractArray{<:Real},
-    )
-        if method_exists(∇, Tuple{typeof(f), Type{Arg{1}}, Real})
-            return Base.broadcast(An->ȳ * ∇(f, Arg{1}, An), A)
-        else
-            return Base.broadcast(An->ȳ * fmad(f, (An,), Val{1}), A)
-        end
-    end
+    @eval ∇(::typeof($f), ::Type{Arg{3}}, p, y, ȳ, f, ::typeof(+), A::∇Array) =
+        method_exists(∇, Tuple{typeof(f), Type{Arg{1}}, Real}) ?
+            broadcast(An->ȳ * ∇(f, Arg{1}, An), A) :
+            broadcast(An->ȳ * fmad(f, (An,), Val{1}), A)
 end

--- a/src/sensitivities/functional/reducedim.jl
+++ b/src/sensitivities/functional/reducedim.jl
@@ -5,21 +5,16 @@ accept_w_default = :(Tuple{Function, typeof(+), AbstractArray{<:∇Scalar}, Any,
 @eval @explicit_intercepts mapreducedim $accept_wo_default [false, false, true, false]
 @eval @explicit_intercepts mapreducedim $accept_w_default [false, false, true, false, true]
 
-function ∇(
-    ::typeof(mapreducedim),
+∇(::typeof(mapreducedim),
     ::Type{Arg{3}},
     p, y, ȳ, f,
     ::typeof(+),
     A::AbstractArray{<:∇Scalar},
     region,
     v0=nothing,
-)
-    if method_exists(∇, Tuple{typeof(f), Type{Arg{1}}, ∇Scalar})
-        return broadcast((An, ȳn)->ȳn * ∇(f, Arg{1}, An), A, ȳ)
-    else
-        return broadcast((An, ȳn)->ȳn * fmad(f, (An,), Val{1}), A, ȳ)
-    end
-end
+) = method_exists(∇, Tuple{typeof(f), Type{Arg{1}}, ∇Scalar}) ?
+        broadcast((An, ȳn)->ȳn * ∇(f, Arg{1}, An), A, ȳ) :
+        broadcast((An, ȳn)->ȳn * fmad(f, (An,), Val{1}), A, ȳ)
 
 # Make `sum` work. It currently fails as the type specification is too restrictive.
 sum(n::Node{<:AbstractArray}, region) = mapreducedim(identity, +, n, region)

--- a/src/sensitivities/indexing.jl
+++ b/src/sensitivities/indexing.jl
@@ -5,7 +5,6 @@ for i = 1:7
     @eval @explicit_intercepts getindex $T [[true]; fill(false, $i - 1)]
 end
 
-# ∇(Ā, ::typeof(getindex), ::Type{Arg{1}}, p, y, ȳ, A, inds...) = setindex!(Ā, ȳ, inds...)
 function ∇(Ā, ::typeof(getindex), ::Type{Arg{1}}, p, y, ȳ, A, inds...)
     Ā[inds...] .+= ȳ
     return Ā

--- a/src/sensitivities/indexing.jl
+++ b/src/sensitivities/indexing.jl
@@ -5,7 +5,11 @@ for i = 1:7
     @eval @explicit_intercepts getindex $T [[true]; fill(false, $i - 1)]
 end
 
-∇(Ā, ::typeof(getindex), ::Type{Arg{1}}, p, y, ȳ, A, inds...) = setindex!(Ā, ȳ, inds...)
+# ∇(Ā, ::typeof(getindex), ::Type{Arg{1}}, p, y, ȳ, A, inds...) = setindex!(Ā, ȳ, inds...)
+function ∇(Ā, ::typeof(getindex), ::Type{Arg{1}}, p, y, ȳ, A, inds...)
+    Ā[inds...] .+= ȳ
+    return Ā
+end
 function ∇(::typeof(getindex), ::Type{Arg{1}}, p, y, ȳ, A, inds...)
     return ∇(zerod_container(A), getindex, Arg{1}, p, y, ȳ, A, inds...)
 end

--- a/src/sensitivities/linalg/triangular.jl
+++ b/src/sensitivities/linalg/triangular.jl
@@ -8,24 +8,21 @@ for (ctor, T) in zip([:LowerTriangular, :UpperTriangular], [:∇ScalarLT, :∇Sc
 
     @eval @explicit_intercepts $ctor Tuple{∇AbstractMatrix}
     @eval ∇(::Type{$ctor}, ::Type{Arg{1}}, p, Y::$T, Ȳ::$T, X::∇AbstractMatrix) = full(Ȳ)
-    @eval function ∇(
+    @eval ∇(
         X̄::∇AbstractMatrix,
         ::Type{$ctor},
         ::Type{Arg{1}},
         p,
         Y::$T,
         Ȳ::$T,
-        X::∇AbstractMatrix
-    )
-        return broadcast!(+, X̄, X̄, Ȳ)
-    end
+        X::∇AbstractMatrix,
+    ) = broadcast!(+, X̄, X̄, Ȳ)
 
     @eval @explicit_intercepts det Tuple{$T}
-    @eval function ∇(::typeof(det), ::Type{Arg{1}}, p, y::∇Scalar, ȳ::∇Scalar, X::$T)
-        data = zeros(X.data)
-        data[diagind(data)] .= ȳ .* y ./ view(X, diagind(X))
-        return $ctor(data)
-    end
+    @eval ∇(::typeof(det), ::Type{Arg{1}}, p, y::∇Scalar, ȳ::∇Scalar, X::$T) =
+        Diagonal(ȳ .* y ./ view(X, diagind(X)))
+
+    # Optimisation for in-place updates.
     @eval function ∇(
         X̄::$T,
         ::typeof(det),
@@ -33,7 +30,7 @@ for (ctor, T) in zip([:LowerTriangular, :UpperTriangular], [:∇ScalarLT, :∇Sc
         p,
         y::∇Scalar,
         ȳ::∇Scalar,
-        X::$T
+        X::$T,
     )
         X̄_diag = view(X̄, diagind(X̄))
         broadcast!((x̄, x, y, ȳ)->x̄ + ȳ * y / x,
@@ -41,14 +38,27 @@ for (ctor, T) in zip([:LowerTriangular, :UpperTriangular], [:∇ScalarLT, :∇Sc
         return X̄
     end
 
-    @eval @explicit_intercepts logdet Tuple{$T}
-    @eval function ∇(::typeof(logdet), ::Type{Arg{1}}, p, y::∇Scalar, ȳ::∇Scalar, X::$T)
-        data = zeros(X.data)
-        data[diagind(data)] .= ȳ ./ view(X, diagind(X))
-        return $ctor(data)
-    end
+    # Optimisation for in-place updates to `Diagonal` sensitivity cache.
     @eval function ∇(
-        X̄::$T,
+        X̄::Diagonal,
+        ::typeof(det),
+        ::Type{Arg{1}},
+        p,
+        y::∇Scalar,
+        ȳ::∇Scalar,
+        X::$T,
+    )
+        X̄.diag .+= ȳ .* y ./ view(X, diagind(X))
+        return X̄
+    end
+
+    @eval @explicit_intercepts logdet Tuple{$T}
+    @eval ∇(::typeof(logdet), ::Type{Arg{1}}, p, y::∇Scalar, ȳ::∇Scalar, X::$T) =
+        Diagonal(ȳ ./ view(X, diagind(X)))
+
+    # Optimisation for in-place updates.
+    @eval function ∇(
+        X̄::∇Array,
         ::typeof(logdet),
         ::Type{Arg{1}},
         p,
@@ -58,6 +68,20 @@ for (ctor, T) in zip([:LowerTriangular, :UpperTriangular], [:∇ScalarLT, :∇Sc
     )
         X̄_diag = view(X̄, diagind(X̄))
         broadcast!((x̄, x, ȳ)->x̄ + ȳ / x, X̄_diag, X̄_diag, view(X, diagind(X)), ȳ)
+        return X̄
+    end
+
+    # Optimisation for in-place updates to `Diagonal` sensitivity cache.
+    @eval function ∇(
+        X̄::Diagonal,
+        ::typeof(logdet),
+        ::Type{Arg{1}},
+        p,
+        y::∇Scalar,
+        ȳ::∇Scalar,
+        X::$T,
+    )
+        X̄.diag .+= ȳ ./ view(X, diagind(X))
         return X̄
     end
 end

--- a/src/sensitivities/scalar.jl
+++ b/src/sensitivities/scalar.jl
@@ -29,7 +29,8 @@ unary_sensitivities, binary_sensitivities = [], []
 for (package, f, arity) in diffrules()
     (package == :NaNMath || (package, f) in ignored_fs) && continue
 
-    eval(Expr(:import, importable(:($package.$f))...))
+    eval(:import $package.$f)
+    @eval import $package.$f
     if arity == 1
         push!(unary_sensitivities, (package, f))
         ∂f∂x = diffrule(package, f, :x)

--- a/src/sensitivities/scalar.jl
+++ b/src/sensitivities/scalar.jl
@@ -26,21 +26,6 @@ ignored_fs = [(:SpecialFunctions, :hankelh1),
 
 unary_sensitivities, binary_sensitivities = [], []
 
-# Code due to Curtis Vogt.
-function importable(ex::Expr)
-    ex.head === :. || error("Expression is not valid as an import: $ex")
-    result = importable_expr(ex.args[1])
-    push!(result, ex.args[2].args[1])
-    return result
-end
-function importable_expr(ex::Expr)
-    ex.head === :. || error("Expression is not valid as an import: $ex")
-    result = importable_expr(ex.args[1])
-    push!(result, ex.args[2].value)
-    return result
-end
-importable_expr(sym::Symbol) = Any[sym]
-
 for (package, f, arity) in diffrules()
     (package == :NaNMath || (package, f) in ignored_fs) && continue
 

--- a/src/sensitivities/scalar.jl
+++ b/src/sensitivities/scalar.jl
@@ -29,7 +29,6 @@ unary_sensitivities, binary_sensitivities = [], []
 for (package, f, arity) in diffrules()
     (package == :NaNMath || (package, f) in ignored_fs) && continue
 
-    eval(:import $package.$f)
     @eval import $package.$f
     if arity == 1
         push!(unary_sensitivities, (package, f))

--- a/src/sensitivities/scalar.jl
+++ b/src/sensitivities/scalar.jl
@@ -1,5 +1,5 @@
 using SpecialFunctions
-using DiffRules: @define_diffrule, diffrule, diffrules, DiffRule
+using DiffRules: @define_diffrule, diffrule, diffrules, hasdiffrule
 
 # Hand code the identity because it's really fundamental. It doesn't need to generate a new
 # node on the computational graph since it does nothing, but it is useful to have it's
@@ -16,14 +16,35 @@ import Base.identity
 
 # Ignore functions that have complex ranges. This may change when Nabla supports complex
 # numbers.
-ignored_fs = [:hankelh1, :hankelh2]
+ignored_fs = [(:SpecialFunctions, :hankelh1),
+              (:SpecialFunctions, :hankelh2),
+              (:(Base.Math.JuliaLibm), :log1p),
+              (:Base, :rem2pi),
+              (:Base, :mod),
+              (:Base, :atan2),
+              (:Base, :rem)]
 
 unary_sensitivities, binary_sensitivities = [], []
 
-for (package, f, arity) in diffrules()
-    (package == :NaNMath || f in ignored_fs) && continue
+# Code due to Curtis Vogt.
+function importable(ex::Expr)
+    ex.head === :. || error("Expression is not valid as an import: $ex")
+    result = importable_expr(ex.args[1])
+    push!(result, ex.args[2].args[1])
+    return result
+end
+function importable_expr(ex::Expr)
+    ex.head === :. || error("Expression is not valid as an import: $ex")
+    result = importable_expr(ex.args[1])
+    push!(result, ex.args[2].value)
+    return result
+end
+importable_expr(sym::Symbol) = Any[sym]
 
-    @eval import $package.$f
+for (package, f, arity) in diffrules()
+    (package == :NaNMath || (package, f) in ignored_fs) && continue
+
+    eval(Expr(:import, importable(:($package.$f))...))
     if arity == 1
         push!(unary_sensitivities, (package, f))
         ∂f∂x = diffrule(package, f, :x)

--- a/src/sensitivity.jl
+++ b/src/sensitivity.jl
@@ -64,7 +64,7 @@ end
 
 """
     boxed_method(
-        f::Symbol,
+        f::SymOrExpr,
         type_tuple::Expr,
         is_node::Vector{Bool},
         arg_names::Vector{Symbol},
@@ -96,7 +96,7 @@ end
 boxed_method(f, t, n) = boxed_method(f, t, n, [gensym() for _ in n])
 
 """
-    get_sig(f::Symbol, arg_names::Vector{Symbol}, types::Vector)
+    get_sig(f::SymOrExpr, arg_names::Vector{Symbol}, types::Vector)
 
 Generate a function signature for `f` in which the arguments, whose names are `arg_names`,
 specified by the `true` entires of `is_node` have type `Node`. The other arguments have

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
 Distributions
-BenchmarkTools 0.0.8 0.0.9
+BenchmarkTools 0.0.8

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,26 +1,26 @@
 using Base.Test, Nabla, Distributions, BenchmarkTools
 
-# @testset "Core" begin
-#     include("core.jl")
-#     include("code_transformation/util.jl")
-#     include("code_transformation/differentiable.jl")
-#     include("sensitivity.jl")
-# end
+@testset "Core" begin
+    include("core.jl")
+    include("code_transformation/util.jl")
+    include("code_transformation/differentiable.jl")
+    include("sensitivity.jl")
+end
 
 @testset "Sensitivities" begin
     include("finite_differencing.jl")
 
-    # # Test sensitivities for the basics.
-    # include("sensitivities/indexing.jl")
-    # include("sensitivities/scalar.jl")
-    # include("sensitivities/array.jl")
+    # Test sensitivities for the basics.
+    include("sensitivities/indexing.jl")
+    include("sensitivities/scalar.jl")
+    include("sensitivities/array.jl")
 
-    # # Test sensitivities for functionals.
-    # @testset "Functional" begin
-    #     include("sensitivities/functional/functional.jl")
-    #     include("sensitivities/functional/reduce.jl")
-    #     include("sensitivities/functional/reducedim.jl")
-    # end
+    # Test sensitivities for functionals.
+    @testset "Functional" begin
+        include("sensitivities/functional/functional.jl")
+        include("sensitivities/functional/reduce.jl")
+        include("sensitivities/functional/reducedim.jl")
+    end
 
     # Test sensitivities for linear algebra optimisations.
     @testset "Linear algebra" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,26 +1,26 @@
 using Base.Test, Nabla, Distributions, BenchmarkTools
 
-@testset "Core" begin
-    include("core.jl")
-    include("code_transformation/util.jl")
-    include("code_transformation/differentiable.jl")
-    include("sensitivity.jl")
-end
+# @testset "Core" begin
+#     include("core.jl")
+#     include("code_transformation/util.jl")
+#     include("code_transformation/differentiable.jl")
+#     include("sensitivity.jl")
+# end
 
 @testset "Sensitivities" begin
     include("finite_differencing.jl")
 
-    # Test sensitivities for the basics.
-    include("sensitivities/indexing.jl")
-    include("sensitivities/scalar.jl")
-    include("sensitivities/array.jl")
+    # # Test sensitivities for the basics.
+    # include("sensitivities/indexing.jl")
+    # include("sensitivities/scalar.jl")
+    # include("sensitivities/array.jl")
 
-    # Test sensitivities for functionals.
-    @testset "Functional" begin
-        include("sensitivities/functional/functional.jl")
-        include("sensitivities/functional/reduce.jl")
-        include("sensitivities/functional/reducedim.jl")
-    end
+    # # Test sensitivities for functionals.
+    # @testset "Functional" begin
+    #     include("sensitivities/functional/functional.jl")
+    #     include("sensitivities/functional/reduce.jl")
+    #     include("sensitivities/functional/reducedim.jl")
+    # end
 
     # Test sensitivities for linear algebra optimisations.
     @testset "Linear algebra" begin

--- a/test/sensitivities/functional/functional.jl
+++ b/test/sensitivities/functional/functional.jl
@@ -1,5 +1,5 @@
 using SpecialFunctions
-using DiffRules: diffrule
+using DiffRules: diffrule, hasdiffrule
 
 @testset "Functional" begin
     # Apparently Distributions.jl doesn't implement the following, so we'll have to do it.
@@ -74,9 +74,14 @@ using DiffRules: diffrule
             @test ∇s[y_] ≈ ∇y
         end
         for (package, f) in Nabla.binary_sensitivities
+
             # TODO: More care needs to be taken to test the following.
-            f in [:atan2, :mod, :rem] && continue
-            ∂f∂x, ∂f∂y = diffrule(package, f, :x, :y)
+            if hasdiffrule(package, f, 2)
+                ∂f∂x, ∂f∂y = diffrule(package, f, :x, :y)
+            else
+                ∂f∂x, ∂f∂y = :∂f∂x, :∂f∂y
+            end
+
             # TODO: Implement the edge cases for functions differentiable in only either
             # argument.
             (∂f∂x == :NaN || ∂f∂y == :NaN) && continue
@@ -190,7 +195,11 @@ using DiffRules: diffrule
         for (package, f) in Nabla.binary_sensitivities
             # TODO: More care needs to be taken to test the following.
             f in [:atan2, :mod, :rem] && continue
-            ∂f∂x, ∂f∂y = diffrule(package, f, :x, :y)
+            if hasdiffrule(package, f, 2)
+                ∂f∂x, ∂f∂y = diffrule(package, f, :x, :y)
+            else
+                ∂f∂x, ∂f∂y = :∂f∂x, :∂f∂y
+            end
             # TODO: Implement the edge cases for functions differentiable in only either
             # argument.
             (∂f∂x == :NaN || ∂f∂y == :NaN) && continue

--- a/test/sensitivities/linalg/triangular.jl
+++ b/test/sensitivities/linalg/triangular.jl
@@ -39,4 +39,15 @@
             @test check_errs(logdet, 10.0, A, VA)
         end
     end
+
+    # Check that the optimisations occur correctly and produce the required types when
+    # everything is Diagonal.
+    let rng = MersenneTwister(123456)
+        A = UpperTriangular(exp.(randn(rng, 10, 10)))
+
+        @test ∇(det)(A)[1] isa Diagonal
+        @test ∇(A->det(A) + det(A))(A)[1] isa Diagonal
+        @test ∇(logdet)(A)[1] isa Diagonal
+        @test ∇(A->logdet(A) + det(A))(A)[1] isa Diagonal
+    end
 end


### PR DESCRIPTION
I've added a couple of small optimsations for determinants of triangular matrices, and generally tidied up the corresponding code a bit. All comments below apply to both `det` and `logdet`.
- Tidied up syntax for constructor sensitivities.
- Allocating implementation now returns a `Diagonal` matrix, rather than a dense matrix. This is valid because a `Diagonal` matrix precisely represents the sensitivities, and doesn't throw away any information.
- Generalised `X̄::$T` to `X̄::∇Array`since it's probably possible for the sensitivity not to be Triangular. I can't actually think of a concrete example for this though, so feel free to critique this.
- Non-allocating sensitivites: added a specialisation for `X̄::Diagonal` which actually does what it says on the tin.