### PR TITLE
Overload isapprox

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -1,6 +1,7 @@
 using DualNumbers
 
-import Base: push!, length, show, getindex, setindex!, endof, eachindex, isassigned
+import Base: push!, length, show, getindex, setindex!, endof, eachindex, isassigned,
+isapprox
 export Leaf, Tape, Node, Branch, ∇
 
 """ Basic unit on the computational graph."""
@@ -97,6 +98,9 @@ Get `.val` if `x` is a Node, otherwise is equivalent to `identity`.
 """
 unbox(x::Node) = x.val
 unbox(x) = x
+
+isapprox(n::Nabla.Branch{T}, f::T) where T = Nabla.unbox(n) ≈ f
+isapprox(f::T, n::Nabla.Branch{T}) where T = n ≈ f
 
 # Leafs do nothing, Branches compute their own sensitivities and update others.
 @inline propagate(y::Leaf, rvs_tape::Tape) = nothing

--- a/src/core.jl
+++ b/src/core.jl
@@ -53,6 +53,9 @@ end
 show(io::IO, tape::Leaf{T}) where T = print(io, "Leaf{$T} $(tape.val)")
 show(io::IO, tape::Leaf{T}) where T<:AbstractArray = print(io, "Leaf{$T} $(size(tape.val))")
 
+isapprox(n::Nabla.Leaf{T}, f::T) where T = Nabla.unbox(n) ≈ f
+isapprox(f::T, n::Nabla.Leaf{T}) where T = n ≈ f
+
 """
 A Branch is a Node with parents (args).
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -103,8 +103,25 @@ let
 
 end # let
 
+# Check that functions involving `isapprox` can be differentiated
+let
+    f(x) = x ≈ 5.0 ? 1.0 : 3.0 * x
+    g(x) = 5.0 * x
+    h(x) = g(x) ≈ 25.0 ? x : f(x) + g(x)
+    ∇f = ∇(f)
+    ∇h = ∇(h)
+    @test ∇f(5.0) == (0.0,)
+    @test ∇f(6.0) == (3.0,)
+    @test ∇h(5.0) == (1.0,)
+    @test ∇h(6.0) == (8.0,)
+    f(x) = x ≈ [5.0] ? 1.0 : 3.0 * sum(x)
+    ∇f = ∇(f)
+    @test ∇f([5.0]) == ([0.0],)
+    @test ∇f([6.0]) == ([3.0],)
+end
+
 # Check that functions with extra, unused variables can be differentiated
-let 
+let
     f(a,b,c,d) = a*c
     ∇f = ∇(f)
     g(a,b) = 12
@@ -113,7 +130,7 @@ let
     @test ∇f(1,2,3,4) == (3, 0, 1, 0)
     @test ∇f(1,[2.0],3,4.0) == (3, [0.0], 1, 0.0)
     @test ∇g(1,2) == (0,0)
-end 
+end
 
 # Check that the convenience implementation of ∇ works as intended.
 let


### PR DESCRIPTION
This PR defines `isapprox` for `Nabla.Branch`es and the types they wrap.