### PR TITLE
Add zero() and one() for branches and leaves

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -53,12 +53,6 @@ end
 show(io::IO, tape::Leaf{T}) where T = print(io, "Leaf{$T} $(tape.val)")
 show(io::IO, tape::Leaf{T}) where T<:AbstractArray = print(io, "Leaf{$T} $(size(tape.val))")
 
-isapprox(n::Nabla.Leaf{T}, f::T) where T = Nabla.unbox(n) ≈ f
-isapprox(f::T, n::Nabla.Leaf{T}) where T = n ≈ f
-
-zero(n::Nabla.Leaf{T}) where T = zero(unbox(n))
-one(n::Nabla.Leaf{T}) where T = one(unbox(n))
-
 """
 A Branch is a Node with parents (args).
 
@@ -105,11 +99,11 @@ Get `.val` if `x` is a Node, otherwise is equivalent to `identity`.
 unbox(x::Node) = x.val
 unbox(x) = x
 
-isapprox(n::Nabla.Branch{T}, f::T) where T = Nabla.unbox(n) ≈ f
-isapprox(f::T, n::Nabla.Branch{T}) where T = n ≈ f
+isapprox(n::Node, f) = Nabla.unbox(n) ≈ f
+isapprox(f, n::Node) = n ≈ f
 
-zero(n::Nabla.Branch{T}) where T = zero(unbox(n))
-one(n::Nabla.Branch{T}) where T = one(unbox(n))
+zero(n::Node) = zero(unbox(n))
+one(n::Node) = one(unbox(n))
 
 # Leafs do nothing, Branches compute their own sensitivities and update others.
 @inline propagate(y::Leaf, rvs_tape::Tape) = nothing

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,7 +1,7 @@
 using DualNumbers
 
 import Base: push!, length, show, getindex, setindex!, endof, eachindex, isassigned,
-isapprox
+isapprox, zero, one
 export Leaf, Tape, Node, Branch, ∇
 
 """ Basic unit on the computational graph."""
@@ -56,6 +56,9 @@ show(io::IO, tape::Leaf{T}) where T<:AbstractArray = print(io, "Leaf{$T} $(size(
 isapprox(n::Nabla.Leaf{T}, f::T) where T = Nabla.unbox(n) ≈ f
 isapprox(f::T, n::Nabla.Leaf{T}) where T = n ≈ f
 
+zero(n::Nabla.Leaf{T}) where T = zero(unbox(n))
+one(n::Nabla.Leaf{T}) where T = one(unbox(n))
+
 """
 A Branch is a Node with parents (args).
 
@@ -104,6 +107,9 @@ unbox(x) = x
 
 isapprox(n::Nabla.Branch{T}, f::T) where T = Nabla.unbox(n) ≈ f
 isapprox(f::T, n::Nabla.Branch{T}) where T = n ≈ f
+
+zero(n::Nabla.Branch{T}) where T = zero(unbox(n))
+one(n::Nabla.Branch{T}) where T = one(unbox(n))
 
 # Leafs do nothing, Branches compute their own sensitivities and update others.
 @inline propagate(y::Leaf, rvs_tape::Tape) = nothing

--- a/test/core.jl
+++ b/test/core.jl
@@ -132,6 +132,21 @@ let
     @test ∇g(1,2) == (0,0)
 end
 
+# Check that functions with `zero` and `one` can be differentiated
+let
+    f(a) = zero(a)
+    g(a) = one(a)
+    h(a) = zero(3 * a) + one(4 * a)
+    ∇f = ∇(f)
+    ∇g = ∇(g)
+    ∇h = ∇(h)
+
+    @test ∇f(1) == (0,)
+    @test ∇f([1]) == ([0],)
+    @test ∇g(4) == (0,)
+    @test ∇h(8) == (0,)
+end
+
 # Check that the convenience implementation of ∇ works as intended.
 let
     f(x, y) = 2x + y


### PR DESCRIPTION
This allows Nabla to differentiate through functions that involve calls to `zero()` and to `one()`.