### PR TITLE
Make adjoint compatible with scalars

### DIFF
--- a/src/sensitivities/linalg/generic.jl
+++ b/src/sensitivities/linalg/generic.jl
@@ -8,6 +8,7 @@ unary_linalg_optimisations = [
     (:logdet,     ∇Array,  ∇Scalar, :(Ȳ * transpose(inv(X))),            (_ϵ, ub)),
     (:transpose,  ∇Array,  ∇Array,  :(transpose(Ȳ)),                     (lb, ub)),
     (:adjoint,    ∇Array,  ∇Array,  :(adjoint(Ȳ)),                       (lb, ub)),
+    (:adjoint,    ∇Scalar,  ∇Scalar,  :(adjoint(Ȳ)),                     (lb, ub)),
     (:norm,       ∇Array,  ∇Scalar, :(Ȳ ./ Y .* abs2.(X) ./ X),          (lb, ub)),
     (:norm,       ∇Scalar, ∇Scalar, :(Ȳ * sign(X)),                      (lb, ub))
 ]

--- a/src/sensitivities/linalg/generic.jl
+++ b/src/sensitivities/linalg/generic.jl
@@ -7,8 +7,8 @@ unary_linalg_optimisations = [
     (:det,        ∇Array,  ∇Scalar, :(Y * Ȳ * transpose(inv(X))),        (_ϵ, ub)),
     (:logdet,     ∇Array,  ∇Scalar, :(Ȳ * transpose(inv(X))),            (_ϵ, ub)),
     (:transpose,  ∇Array,  ∇Array,  :(transpose(Ȳ)),                     (lb, ub)),
+    (:adjoint,    ∇Scalar, ∇Scalar, :(adjoint(Ȳ)),                       (_ϵ, ub)),
     (:adjoint,    ∇Array,  ∇Array,  :(adjoint(Ȳ)),                       (lb, ub)),
-    (:adjoint,    ∇Scalar,  ∇Scalar,  :(adjoint(Ȳ)),                     (lb, ub)),
     (:norm,       ∇Array,  ∇Scalar, :(Ȳ ./ Y .* abs2.(X) ./ X),          (lb, ub)),
     (:norm,       ∇Scalar, ∇Scalar, :(Ȳ * sign(X)),                      (lb, ub))
 ]


### PR DESCRIPTION
Currently, `adjoint` only has sensitivities for arrays. This MR adds scalars. Case in point:

current master:
```julia
julia> f(x) = sum(x')
f (generic function with 1 method)

julia> ∇(f)(rand(5))
([1.0, 1.0, 1.0, 1.0, 1.0],)

julia> ∇(f)(rand(5, 5))
([1.0 1.0 … 1.0 1.0; 1.0 1.0 … 1.0 1.0; … ; 1.0 1.0 … 1.0 1.0; 1.0 1.0 … 1.0 1.0],)

julia> ∇(f)(4)
ERROR: MethodError: no method matching adjoint(::Leaf{Int64})
Closest candidates are:
  adjoint(::Missing) at missing.jl:79
  adjoint(::Number) at number.jl:193
```

this branch:
```julia
julia> f(x) = sum(x')
f (generic function with 1 method)

julia> ∇(f)(rand(5, 5))
([1.0 1.0 … 1.0 1.0; 1.0 1.0 … 1.0 1.0; … ; 1.0 1.0 … 1.0 1.0; 1.0 1.0 … 1.0 1.0],)

julia> ∇(f)(rand(5))
([1.0, 1.0, 1.0, 1.0, 1.0],)

julia> ∇(f)(5)
(1,)
```