### PR TITLE
Fix broadcasting (handle deep Broadcasted)

### DIFF
--- a/src/sensitivities/functional/functional.jl
+++ b/src/sensitivities/functional/functional.jl
@@ -35,10 +35,10 @@ Base.BroadcastStyle(::NodeStyle{S}, B::BroadcastStyle) where {S} =
 Broadcast.broadcast_axes(x::Node) = broadcast_axes(x.val)
 Broadcast.broadcastable(x::Node) = x
 
-function Base.copy(bc::Broadcasted{<:NodeStyle})
-    args = bc.args
+# eagerly construct a Branch when encountering a Node in broadcasting
+function Broadcast.broadcasted(::NodeStyle, f, args...)
     tape = getfield(args[findfirst(x -> x isa Node, args)], :tape)
-    return Branch(broadcast, (bc.f, args...), tape)
+    return Branch(broadcast, (f, args...), tape)
 end
 
 """

--- a/test/sensitivities/functional/functional.jl
+++ b/test/sensitivities/functional/functional.jl
@@ -231,4 +231,12 @@ using DiffRules: diffrule, hasdiffrule
             @test allocs(@benchmark ∇(foo_small())) == allocs(@benchmark ∇(foo_large()))
         end
     end
+
+    # #111
+    let
+        f(x) = sum(Float64[1,2,3] .* (x .+ Float64[3,2,1]))
+        ∇f = ∇(f)
+        @test ∇(f)(Float64[1,2,3]) isa Tuple{Vector{Float64}}
+        @test ∇(f; get_output=true)(Float64[1,2,3])[1].val == f(Float64[1,2,3])
+    end
 end


### PR DESCRIPTION
Fixes #111 and tests for it

This will create a `Branch` each time a `Node` is encountered during broadcasting (including the `Branch` created by a fused broadcast). 