### PR TITLE
Fix broadcasting Refs

### DIFF
--- a/src/sensitivities/functional/functional.jl
+++ b/src/sensitivities/functional/functional.jl
@@ -77,8 +77,11 @@ function broadcastsum(f, add::Bool, z::Number, As...)
     return sum(broadcast!(f, tmp, As...)) + (add ? z : zero(z))
 end
 
+broadcastsum(f, add::Bool, z::Ref{<:Number}, As...) = broadcastsum(f, add, z[], As...)
+
 # Compute sensitivity w.r.t. the N^{th} input, N > 1.
-∇(::typeof(broadcast), ::Type{Arg{N}}, p, y, ȳ, f, A::∇ArrayOrScalar...) where N =
+const ∇Broadcastable = Union{∇ArrayOrScalar, Ref{<:∇Scalar}}
+∇(::typeof(broadcast), ::Type{Arg{N}}, p, y, ȳ, f, A::∇Broadcastable...) where N =
     _∇(broadcast, Arg{N-1}, p, y, ȳ, f, A...)
 _∇(::typeof(broadcast), ::Type{Arg{N}}, p, y, ȳ, f, A...) where N =
     hasmethod(∇, Tuple{typeof(f), Type{Arg{N}}, Any, Any, Any, map(eltype, A)...}) ?

--- a/test/sensitivities/functional/functional.jl
+++ b/test/sensitivities/functional/functional.jl
@@ -216,6 +216,8 @@ using DiffRules: diffrule, hasdiffrule
             check_binary_dot(eval(f), x, y)
             check_binary_dot(eval(f), rand(rng, x_distr), y)
             check_binary_dot(eval(f), x, rand(rng, y_distr))
+            check_binary_dot(eval(f), Ref(rand(rng, x_distr)), y)
+            check_binary_dot(eval(f), x, Ref(rand(rng, y_distr)))
             check_binary_dot(eval(f), rand(rng, x_distr), rand(rng, y_distr))
         end
     end


### PR DESCRIPTION
Broadcasting over a `Ref` use to fail, as in this example:

```julia
julia> func(x) = sum(x .* Ref(2))
func (generic function with 1 method)

julia> ∇(func)(rand(5))
ERROR: MethodError: no method matching ∇(::typeof(broadcast), ::Type{Arg{2}}, ::Tuple{}, ::Array{Float64,1}, ::Array{Float64,1}, ::typeof(*), ::Array{Float64,1}, ::Base.RefValue{Int64})
Closest candidates are:
  ∇(::typeof(broadcast), ::Type{Arg{N}}, ::Any, ::Any, ::Any, ::Any, ::Union{Number, Ref{Number}, AbstractArray{#s12,N} where N where #s12<:Number}...) where N at /Users/ericdavies/.julia/dev/Nabla/src/sensitivities/functional/functional.jl:83
  ∇(::Any, ::Any, ::Type{Arg{N}}, ::Any...) where N at /Users/ericdavies/.julia/dev/Nabla/src/core.jl:169
  ∇(::typeof(getindex), ::Type{Arg{1}}, ::Any, ::Any, ::Any, ::Any, ::Any...) at /Users/ericdavies/.julia/dev/Nabla/src/sensitivities/indexing.jl:18
```

It is necessary to support `Ref` in broadcasting as this is how scalars can be explicitly indicated. Putting `Ref` around a `Number` should have no effect. This PR implements that behaviour. 