### PR TITLE
Set version in Project.toml to 0.3.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nabla"
 uuid = "49c96f43-aa6d-5a04-a506-44c7070ebe78"
-version = "0.2.0"
+version = "0.3.1"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"


### PR DESCRIPTION
0.3.0 was tagged with the Project.toml claiming it to be 0.2.0, so we can tag a 0.3.1 with this fix to ensure the versions match.