### PR TITLE
Use accessor functions and getfield calls instead of .

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.jl.mem
 *.pdf
 *.DS_Store
+Manifest.toml
 docs/build/

--- a/examples/asymmetric_quadratic.jl
+++ b/examples/asymmetric_quadratic.jl
@@ -17,7 +17,7 @@ z = x.' * (A * y) # Temporary bracketting because we don't support RowVectors ye
 println("Output of the forward pass is:")
 println(z)
 println()
-println("y.val is $(z.val).")
+println("y is $(Nabla.unbox(z)).")
 println()
 
 # Get the reverse tape.

--- a/examples/symmetric_quadratic.jl
+++ b/examples/symmetric_quadratic.jl
@@ -16,7 +16,7 @@ y = x.' * (A * x) # Temporary bracketting because we don't support RowVectors ye
 println("Output of the forward pass is:")
 println(y)
 println()
-println("y.val is $(y.val).")
+println("y is $(Nabla.unbox(y)).")
 println()
 
 # Get the reverse tape.
@@ -27,7 +27,7 @@ println()
 
 # Index into the reverse tape using x to get the gradient of `y` w.r.t. `x`.
 x̄ = ȳ[x]
-println("Gradient of y w.r.t. x at $(x.val) is $x̄.")
+println("Gradient of y w.r.t. x at $(Nabla.unbox(x)) is $x̄.")
 println()
 
 # (Current) High-Level API computation of derivatives. I will probably maintain this

--- a/src/finite_differencing.jl
+++ b/src/finite_differencing.jl
@@ -67,18 +67,18 @@ function compute_Dv_update(
     # Randomly initialise `Leaf`s.
     inits = Vector(undef, length(rtape))
     for i = 1:length(rtape)
-        if isleaf(y.tape[i])
-            inits[i] = randned_container(y.tape[i].val)
+        if isleaf(tape(y)[i])
+            inits[i] = randned_container(unbox(tape(y)[i]))
             rtape[i] = copy(inits[i])
         end
     end
 
     # Perform the reverse pass.
-    ∇f = propagate(y.tape, rtape)
+    ∇f = propagate(tape(y), rtape)
 
     # Substract the random initialisations.
     for i = 1:length(rtape)
-        isleaf(y.tape[i]) && (∇f[i] -= inits[i])
+        isleaf(tape(y)[i]) && (∇f[i] -= inits[i])
     end
 
     return sum(map((x, v)->sum(∇f[x] .* v), x_, v))

--- a/src/sensitivities/array.jl
+++ b/src/sensitivities/array.jl
@@ -1,8 +1,8 @@
 import Base: size, length, reshape, hcat, vcat
 
 # Let the user get the `size` and `length` of `Node`s.
-Base.size(x::Node, dims...) = size(x.val, dims...)
-Base.length(x::Node) = length(x.val)
+Base.size(x::Node, dims...) = size(unbox(x), dims...)
+Base.length(x::Node) = length(unbox(x))
 
 # Sensitivity for the first argument of `reshape`.
 @explicit_intercepts reshape Tuple{∇Array, Vararg{Int}} [true, false]

--- a/src/sensitivities/functional/functional.jl
+++ b/src/sensitivities/functional/functional.jl
@@ -36,7 +36,7 @@ function Base.BroadcastStyle(::NodeStyle{S}, B::BroadcastStyle) where {S}
     promoted isa Broadcast.Unknown ? promoted : NodeStyle{promoted}()
 end
 
-Broadcast.broadcast_axes(x::Node) = broadcast_axes(x.val)
+Broadcast.broadcast_axes(x::Node) = broadcast_axes(unbox(x))
 Broadcast.broadcastable(x::Node) = x
 
 # eagerly construct a Branch when encountering a Node in broadcasting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Nabla
 using Test, LinearAlgebra, Statistics, Random
 using Distributions, BenchmarkTools, SpecialFunctions, DualNumbers
 
-using Nabla: oneslike, zeroslike
+using Nabla: unbox, pos, tape, oneslike, zeroslike
 
 @testset "Core" begin
     include("core.jl")

--- a/test/sensitivities/functional/reduce.jl
+++ b/test/sensitivities/functional/reduce.jl
@@ -33,7 +33,7 @@
                     # Test +.
                     x_ = Leaf(Tape(), x)
                     s = functional(f, +, x_)
-                    @test s.val ≈ functional(f, +, x)
+                    @test unbox(s) ≈ functional(f, +, x)
                     @test ∇(s)[x_] ≈ map(x->fmad(f, (x,), Val{1}), x)
                 end
             end
@@ -52,7 +52,7 @@
                 x = randn(rng, 100)
                 x_ = Leaf(Tape(), x)
                 s = functional(+, x_)
-                @test s.val == functional(+, x)
+                @test unbox(s) == functional(+, x)
                 @test ∇(s)[x_] ≈ oneslike(100)
             end
         end
@@ -73,7 +73,7 @@
                 # Test +.
                 x_ = Leaf(Tape(), x)
                 s = sum(f, x_)
-                @test s.val == sum(f, x)
+                @test unbox(s) == sum(f, x)
                 @test ∇(s)[x_] ≈ ∇.(f, Arg{1}, x)
             end
 
@@ -87,7 +87,7 @@
                 # Test +.
                 x_ = Leaf(Tape(), x)
                 s = sum(f, x_)
-                @test s.val == sum(f, x)
+                @test unbox(s) == sum(f, x)
                 @test ∇(s)[x_] ≈ map(x->fmad(f, (x,), Val{1}), x)
             end
         end

--- a/test/sensitivities/functional/reducedim.jl
+++ b/test/sensitivities/functional/reducedim.jl
@@ -12,44 +12,44 @@ end
         # mapreducedim on a single-dimensional array should be consistent with mapreduce.
         x = Leaf(Tape(), [1.0, 2.0, 3.0, 4.0, 5.0])
         s = 5.0 * mapreduce(abs2, +, x, dims=1)
-        @test ∇(s, oneslike(s.val))[x] ≈ 5.0 * [2.0, 4.0, 6.0, 8.0, 10.0]
+        @test ∇(s, oneslike(unbox(s)))[x] ≈ 5.0 * [2.0, 4.0, 6.0, 8.0, 10.0]
 
         # mapreduce on a two-dimensional array when reduced over a single dimension
         # should give different results to mapreduce over the same array.
         x2_ = reshape([1.0, 2.0, 3.0, 4.0,], (2, 2))
         x2 = Leaf(Tape(), x2_)
         s = mapreduce(abs2, +, x2, dims=1)
-        @test ∇(s, oneslike(s.val))[x2] ≈ 2.0 * x2_
+        @test ∇(s, oneslike(unbox(s)))[x2] ≈ 2.0 * x2_
 
         # mapreducedim under `exp` should trigger the first conditional in the ∇ impl.
         x3_ = randn(rng, 5, 4)
         x3 = Leaf(Tape(), x3_)
         s = mapreduce(exp, +, x3, dims=1)
-        @test ∇(s, oneslike(s.val))[x3] == exp.(x3_)
+        @test ∇(s, oneslike(unbox(s)))[x3] == exp.(x3_)
 
         # mapreducedim under an anonymous-function should trigger fmad.
         x4_ = randn(rng, 5, 4)
         x4 = Leaf(Tape(), x4_)
         s = mapreduce(x->x*x, +, x4, dims=2)
-        @test ∇(s, oneslike(s.val))[x4] == 2x4_
+        @test ∇(s, oneslike(unbox(s)))[x4] == 2x4_
 
         # Check that `sum` works correctly with `Node`s.
         x_sum = Leaf(Tape(), randn(rng, 5, 4, 3))
-        @test sum(x_sum, dims=[2, 3]).val == mapreduce(identity, +, x_sum, dims=[2, 3]).val
+        @test unbox(sum(x_sum, dims=[2, 3])) == unbox(mapreduce(identity, +, x_sum, dims=[2, 3]))
 
         # Ensure that the underlying value is correct in the presence of keyword arguments
         x5_ = ones(5, 4, 3)
         x5 = Leaf(Tape(), x5_)
-        @test sum(x5, dims=1).val == sum(x5_, dims=1) == fill(5.0, (1, 4, 3))
-        @test sum(x5, dims=2).val == sum(x5_, dims=2) == fill(4.0, (5, 1, 3))
-        @test sum(x5, dims=3).val == sum(x5_, dims=3) == fill(3.0, (5, 4, 1))
-        @test sum(x5).val == 60.0
-        @test sum(x5).f === Nabla._mapreduce
-        @test mean(x5, dims=1).val == mean(x5_, dims=1) == fill(1.0, (1, 4, 3))
-        @test mean(x5, dims=2).val == mean(x5_, dims=2) == fill(1.0, (5, 1, 3))
-        @test mean(x5, dims=3).val == mean(x5_, dims=3) == fill(1.0, (5, 4, 1))
-        @test mean(x5).val == 1.0
-        @test mean(x5).f === Base.:/
+        @test unbox(sum(x5, dims=1)) == sum(x5_, dims=1) == fill(5.0, (1, 4, 3))
+        @test unbox(sum(x5, dims=2)) == sum(x5_, dims=2) == fill(4.0, (5, 1, 3))
+        @test unbox(sum(x5, dims=3)) == sum(x5_, dims=3) == fill(3.0, (5, 4, 1))
+        @test unbox(sum(x5)) == 60.0
+        @test getfield(sum(x5), :f) === Nabla._mapreduce
+        @test unbox(mean(x5, dims=1)) == mean(x5_, dims=1) == fill(1.0, (1, 4, 3))
+        @test unbox(mean(x5, dims=2)) == mean(x5_, dims=2) == fill(1.0, (5, 1, 3))
+        @test unbox(mean(x5, dims=3)) == mean(x5_, dims=3) == fill(1.0, (5, 4, 1))
+        @test unbox(mean(x5)) == 1.0
+        @test getfield(mean(x5), :f) === Base.:/
 
         # Issue #123
         x6_ = collect(1:10)

--- a/test/sensitivities/indexing.jl
+++ b/test/sensitivities/indexing.jl
@@ -2,14 +2,14 @@
     let
         leaf = Leaf(Tape(), 5 * [1, 1, 1, 1, 1])
         y = getindex(leaf, 1)
-        @test y.val == 5
-        @test ∇(y, one(y.val))[leaf] == [1, 0, 0, 0, 0]
+        @test unbox(y) == 5
+        @test ∇(y, one(unbox(y)))[leaf] == [1, 0, 0, 0, 0]
     end
 
     let
         x = Leaf(Tape(), 10 * [1, 1, 1])
         y = x[2:3]
-        @test y.val == [10, 10]
-        @test ∇(y, oneslike(y.val))[x] == [0, 1, 1]
+        @test unbox(y) == [10, 10]
+        @test ∇(y, oneslike(unbox(y)))[x] == [0, 1, 1]
     end
 end


### PR DESCRIPTION
Avoiding the use of `.` will permit us to trace `getproperty` calls, which could aid in adapting our Cholesky factorization function `chol` to use the newer form from LinearAlgebra. See discussion in #105. I suspect this will be useful for #124 as well.

As accessing the `tape` field was rather pervasive, I've added an accessor function called `tape` which is not exported, like its siblings `unbox` and `pos`. I find that this provides a readability improvement over `getfield(x, :tape)`.

With this change, Nabla users should take care not to access `val` or other fields using `.` but rather with an accessor or with explicit `getfield` calls.