### PR TITLE
Allow destructuring SVD objects in Branches

### DIFF
--- a/src/sensitivities/linalg/factorization/svd.jl
+++ b/src/sensitivities/linalg/factorization/svd.jl
@@ -28,6 +28,14 @@ function ∇(::typeof(getproperty), ::Type{Arg{1}}, p, y, ȳ, USV::SVD, x::Symb
     end
 end
 
+# Iteration allows destructuring, e.g. U, S, V = svd(A)
+# These definitions mirror those defined in the LinearAlgebra module, see
+# https://github.com/JuliaLang/julia/blob/master/stdlib/LinearAlgebra/src/svd.jl#L20-L24
+Base.iterate(usv::Branch{<:SVD}) = (usv.U, Val(:S))
+Base.iterate(usv::Branch{<:SVD}, ::Val{:S}) = (usv.S, Val(:V))
+Base.iterate(usv::Branch{<:SVD}, ::Val{:V}) = (usv.V, Val(:done))
+Base.iterate(usv::Branch{<:SVD}, ::Val{:done}) = nothing
+
 """
     svd_rev(USV, Ū, S̄, V̄)
 

--- a/test/sensitivities/linalg/factorization/svd.jl
+++ b/test/sensitivities/linalg/factorization/svd.jl
@@ -28,6 +28,11 @@
         @test unbox(USV.U) ≈ Matrix{Float64}(I, 3, 3)
         @test unbox(USV.S) ≈ ones(Float64, 3)
         @test unbox(USV.V) ≈ Matrix{Float64}(I, 5, 3)
+        # Destructuring via iteration
+        U, S, V = USV
+        @test U isa Branch{<:Matrix}
+        @test S isa Branch{<:Vector}
+        @test V isa Branch{<:Adjoint}
     end
 
     @testset "Helper functions" begin


### PR DESCRIPTION
This defines `Base.iterate(::Branch{<:SVD})` to allow the common pattern of `U, S, V = svd(A)`.