### PR TITLE
Add sensitivies for copy

### DIFF
--- a/src/sensitivities/linalg/generic.jl
+++ b/src/sensitivities/linalg/generic.jl
@@ -158,3 +158,8 @@ end
 ∇(::typeof(LinearAlgebra.dot), ::Type{Arg{2}}, p, z, z̄, x::A, y::A) = z̄ .* x
 ∇(x̄, ::typeof(LinearAlgebra.dot), ::Type{Arg{1}}, p, z, z̄, x::A, y::A) = (x̄ .= x̄ .+ z̄ .* y)
 ∇(ȳ, ::typeof(LinearAlgebra.dot), ::Type{Arg{2}}, p, z, z̄, x::A, y::A) = (ȳ .= ȳ .+ z̄ .* x)
+
+# `copy` materializes `Adjoint` and `Transpose` wrappers but can be called on anything
+import Base: copy
+@explicit_intercepts copy Tuple{Any}
+∇(::typeof(copy), ::Type{Arg{1}}, p, Y, Ȳ, A) = copy(Ȳ)

--- a/test/sensitivities/linalg/generic.jl
+++ b/test/sensitivities/linalg/generic.jl
@@ -43,4 +43,26 @@
             @test check_errs(LinearAlgebra.dot, LinearAlgebra.dot(x, y), (x, y), (vx, vy))
         end
     end
+
+    @testset "copy" begin
+        rng = MersenneTwister(12345)
+
+        # Scalars (no-op)
+        x = randn(rng)
+        y = randn(rng)
+        @test check_errs(copy, x, x, y)
+        x_ = Leaf(Tape(), x)
+        c = copy(x_)
+        @test c isa Branch{Float64}
+        @test getfield(c, :f) === Base.copy
+
+        # Unwrapping adjoint/transposes
+        X = randn(rng, 6, 6)'
+        Y = randn(rng, 6, 6)
+        @test check_errs(copy, X, copy(X), Y)
+        X_ = Leaf(Tape(), X)
+        C = copy(X_)
+        @test C isa Branch{Matrix{Float64}}
+        @test getfield(c, :f) === Base.copy
+    end
 end


### PR DESCRIPTION
`copy` materializes `Adjoint` and `Transpose` wrappers, which can be useful, as those are immutable. It is also safe to call on any value.