### PR TITLE
Remove sensitivities for + and - on mixed array/scalar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ DiffRules = "0.0"
 DualNumbers = "0.6.0"
 FDM = "0.1.0, 0.2.0"
 SpecialFunctions = ">=0.5.0"
-julia = "0.7, 1.0"
+julia = "1.0"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7
+julia 1.0
 DualNumbers 0.6.0
 DiffRules 0.0.1
 FDM 0.1.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.7
-  - julia_version: 1
+  - julia_version: 1.0
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:

--- a/src/sensitivities/functional/functional.jl
+++ b/src/sensitivities/functional/functional.jl
@@ -93,10 +93,10 @@ _∇(::typeof(broadcast), ::Type{Arg{N}}, p, y, ȳ, f, A...) where N =
 
 # Addition.
 import Base: +
-@eval @explicit_intercepts $(Symbol("+")) Tuple{∇ArrayOrScalar, ∇ArrayOrScalar}
-@inline ∇(::typeof(+), ::Type{Arg{1}}, p, z, z̄, x::∇ArrayOrScalar, y::∇ArrayOrScalar) =
+@eval @explicit_intercepts $(Symbol("+")) Tuple{∇Array, ∇Array}
+@inline ∇(::typeof(+), ::Type{Arg{1}}, p, z, z̄, x::∇Array, y::∇Array) =
     ∇(broadcast, Arg{2}, p, z, z̄, +, x, y)
-@inline ∇(::typeof(+), ::Type{Arg{2}}, p, z, z̄, x::∇ArrayOrScalar, y::∇ArrayOrScalar) =
+@inline ∇(::typeof(+), ::Type{Arg{2}}, p, z, z̄, x::∇Array, y::∇Array) =
     ∇(broadcast, Arg{3}, p, z, z̄, +, x, y)
 
 # Multiplication.
@@ -109,10 +109,10 @@ import Base: *
 
 # Subtraction.
 import Base: -
-@eval @explicit_intercepts $(Symbol("-")) Tuple{∇ArrayOrScalar, ∇ArrayOrScalar}
-@inline ∇(::typeof(-), ::Type{Arg{1}}, p, z, z̄, x::∇ArrayOrScalar, y::∇ArrayOrScalar) =
+@eval @explicit_intercepts $(Symbol("-")) Tuple{∇Array, ∇Array}
+@inline ∇(::typeof(-), ::Type{Arg{1}}, p, z, z̄, x::∇Array, y::∇Array) =
     ∇(broadcast, Arg{2}, p, z, z̄, -, x, y)
-@inline ∇(::typeof(-), ::Type{Arg{2}}, p, z, z̄, x::∇ArrayOrScalar, y::∇ArrayOrScalar) =
+@inline ∇(::typeof(-), ::Type{Arg{2}}, p, z, z̄, x::∇Array, y::∇Array) =
     ∇(broadcast, Arg{3}, p, z, z̄, -, x, y)
 
 # Division from the right by a scalar.

--- a/test/sensitivities/functional/functional.jl
+++ b/test/sensitivities/functional/functional.jl
@@ -2,10 +2,6 @@ using SpecialFunctions
 using DiffRules: diffrule, hasdiffrule
 
 @testset "Functional" begin
-    # Apparently Distributions.jl doesn't implement the following, so we'll have to do it.
-    Random.rand(rng::AbstractRNG, a::Distribution, n::Integer) =
-        [rand(rng, a) for _ in 1:n]
-
     let rng = MersenneTwister(123456)
         import Nabla.fmad
 


### PR DESCRIPTION
Base no longer defines `+(x, y)` and `-(x, y)` where one of `x` or `y` is an array and the other is a scalar. To avoid Bad Things™ sneaking in, this removes our sensitivities for those methods that fall back to broadcast.

I've also included a separate commit for a change that's also present in #140, which is to remove the `rand` method in the tests. It currently errors due to method ambiguities with Distributions and is no longer needed.