### PR TITLE
Use explicit_intercepts for sum

### DIFF
--- a/src/sensitivities/functional/reducedim.jl
+++ b/src/sensitivities/functional/reducedim.jl
@@ -19,7 +19,49 @@ import Base: mapreduce, sum
             broadcast((An, ȳn)->ȳn * ∇(f, Arg{1}, An), A, ȳ) :
             broadcast((An, ȳn)->ȳn * fmad(f, (An,), Val{1}), A, ȳ)
     end
-end
 
-# Make `sum` work. It currently fails as the type specification is too restrictive.
-sum(n::Node{<:AbstractArray}; dims=:) = mapreduce(identity, Base.add_sum, n, dims=dims)
+    @explicit_intercepts(
+        sum,
+        Tuple{Function, AbstractArray{<:∇Scalar}},
+        [false, true],
+        (dims=:,),
+    )
+    @explicit_intercepts(
+        sum,
+        Tuple{AbstractArray{<:∇Scalar}},
+        [true],
+        (dims=:,),
+    )
+    function ∇(
+        ::typeof($(kwfname(sum))),
+        ::Type{Arg{2}},
+        p, y, ȳ,
+        f::Function,
+        A::AbstractArray{<:∇Scalar},
+        dims=:,
+    )
+        # Just pass through to mapreduce
+        return ∇($(kwfname(mapreduce)), Arg{3}, p, y, ȳ, f, Base.add_sum, A, dims)
+    end
+    function ∇(
+        ::typeof($(kwfname(sum))),
+        ::Type{Arg{1}},
+        p, y, ȳ,
+        A::AbstractArray{<:∇Scalar},
+        dims=:,
+    )
+        # Again pass through to mapreduce, using identity as the mapped function
+        return ∇($(kwfname(mapreduce)), Arg{3}, p, y, ȳ, identity, Base.add_sum, A, dims)
+    end
+    # Specialize on sum(abs2, x) as it's a common pattern with a simple derivative
+    function ∇(
+        ::typeof($(kwfname(sum))),
+        ::Type{Arg{2}},
+        p, y, ȳ,
+        ::typeof(abs2),
+        A::AbstractArray{<:∇Scalar},
+        dims=:,
+    )
+        return 2ȳ .* A
+    end
+end

--- a/test/sensitivities/functional/reducedim.jl
+++ b/test/sensitivities/functional/reducedim.jl
@@ -44,7 +44,7 @@ end
         @test unbox(sum(x5, dims=2)) == sum(x5_, dims=2) == fill(4.0, (5, 1, 3))
         @test unbox(sum(x5, dims=3)) == sum(x5_, dims=3) == fill(3.0, (5, 4, 1))
         @test unbox(sum(x5)) == 60.0
-        @test getfield(sum(x5), :f) === Nabla._mapreduce
+        @test getfield(sum(x5), :f) === Nabla._sum
         @test unbox(mean(x5, dims=1)) == mean(x5_, dims=1) == fill(1.0, (1, 4, 3))
         @test unbox(mean(x5, dims=2)) == mean(x5_, dims=2) == fill(1.0, (5, 1, 3))
         @test unbox(mean(x5, dims=3)) == mean(x5_, dims=3) == fill(1.0, (5, 4, 1))
@@ -57,5 +57,11 @@ end
         @test ∇(x->sum(sum(x, dims=2)))(x6_) == (oneslike(x6_),)
         @test ∇((x, y)->sum(sum(x, dims=2) .+ sum(y, dims=2)'))(x6_, x6_) == tens
         @test ∇((x, y)->sum(x .+ y'))(x6_, x6_) == tens
+
+        @test check_errs(sum, randn(rng), randn(rng, 10), randn(rng, 10))
+        # Specialization on the function argument works
+        @test check_errs(x->sum(abs2, x), randn(rng), randn(rng, 10), randn(rng, 10))
+        # Function argument with no specialization also works
+        @test check_errs(x->log(sum(exp, x)), randn(rng), randn(rng, 10), randn(rng, 10))
     end
 end


### PR DESCRIPTION
This allows us to consume and record `sum` calls as such, rather than simply recording that `mapreduce` was called. This should make reading the tape a bit more informative, plus it permits specializations on the particular mapping function `f` passed in `sum(f, x)`.

Because of the aforementioned specialization feature, we can now add a specialization for `sum(abs2, x)`, which is a common pattern and is equivalent to `dot(x, x)` and `sum(x.^2)`.