### PR TITLE
Make printing of Tapes more verbose (and informative)

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -15,11 +15,14 @@ struct Tape
     Tape(N::Int) = new(Vector{Any}(undef, N))
 end
 function show(io::IO, t::Tape)
-    if length(t) == 0
-        println(io, "Empty tape.")
-    else
-        for n in eachindex(t)
-            println(io, n, " ", isassigned(tape(t), n) ? t[n] : "#undef")
+    n = length(t)
+    print(io, "Tape with ", n, " element", n == 1 ? "" : "s", n > 0 ? ":" : "")
+    for i in eachindex(t)
+        print(io, "\n  [", i, "]: ")
+        if isassigned(tape(t), i)
+            show(io, t[i])
+        else
+            print(io, "#undef")
         end
     end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,6 +1,6 @@
 @testset "core" begin
 
-let
+@testset "Tape" begin
     # Simple tests for `Tape`.
     @test getindex(setindex!(Tape(5), "hi", 5), 5) == "hi"
     @test lastindex(Tape(50)) == 50
@@ -11,27 +11,24 @@ let
     @test !isassigned(Tape(26), 26)
 
     # Check that printing works as expected.
-    let
+    @testset "printing" begin
         buffer = IOBuffer()
         show(buffer, Tape())
-        @test String(take!(buffer)) == "Empty tape.\n"
-    end
-    let
+        @test String(take!(buffer)) == "Tape with 0 elements"
+
         buffer = IOBuffer()
         show(buffer, Tape(1))
-        @test String(take!(buffer)) == "1 #undef\n"
-    end
-    let
+        @test String(take!(buffer)) == "Tape with 1 element:\n  [1]: #undef"
+
         buffer = IOBuffer()
         show(buffer, Tape(2))
-        @test String(take!(buffer)) == "1 #undef\n2 #undef\n"
-    end
-    let
+        @test String(take!(buffer)) == "Tape with 2 elements:\n  [1]: #undef\n  [2]: #undef"
+
         buffer = IOBuffer()
         tape_ = Tape(1)
         tape_[1] = 5
         show(buffer, tape_)
-        @test String(take!(buffer)) == "1 5\n"
+        @test String(take!(buffer)) == "Tape with 1 element:\n  [1]: 5"
     end
 
     # Check isassigned consistency.
@@ -101,7 +98,7 @@ let
     @test ∇(br, 3)[br] == 3
     @test ∇(br, 2)[br.args[1]] == 2 * foo_coeff
 
-end # let
+end # testset Tape
 
 # Check that functions involving `isapprox` can be differentiated
 let


### PR DESCRIPTION
Currently the printing of `Tape`s leaves a bit to be desired in terms of examining the actual contents, due in part to the lack of separation between position and value, and due to how values are printed. With this
change, values are printed using `show`, which is the intended way to display things nicely, and positions are wrapped in brackets with a colon. Additionally, a header is printed that lists the number of tape elements, in the same manner as e.g. `Dict`s.

Here is an example of the proposed printing in action:
```
julia> t = Tape()
Tape with 0 elements

julia> x = Leaf(t, transpose([1 2; 3 4]));

julia> t
Tape with 1 element:
  [1]: Leaf{LinearAlgebra.Transpose{Int64,Array{Int64,2}}} (2, 2)

julia> copy(x);

julia> t
Tape with 2 elements:
  [1]: Leaf{LinearAlgebra.Transpose{Int64,Array{Int64,2}}} (2, 2)
  [2]: Branch{Array{Int64,2}} (2, 2) f=copy
```

Compare this to the current printing:
```
julia> t = Tape()
Empty tape.


julia> x = Leaf(t, transpose([1 2; 3 4]));

julia> t
1 Leaf{LinearAlgebra.Transpose{Int64,Array{Int64,2}}} (2, 2)


julia> copy(x);

julia> t
1 Leaf{LinearAlgebra.Transpose{Int64,Array{Int64,2}}} (2, 2)
2 Branch{Array{Int64,2}} (2, 2) f=copy
```