### PR TITLE
Break `isapprox` method ambiguity

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -116,6 +116,7 @@ unbox(x) = x
 
 isapprox(n::Node, f) = unbox(n) ≈ f
 isapprox(f, n::Node) = n ≈ f
+isapprox(n::Node, f::Node) = unbox(n) ≈ unbox(f)
 
 zero(n::Node) = zero(unbox(n))
 one(n::Node) = one(unbox(n))

--- a/test/core.jl
+++ b/test/core.jl
@@ -115,6 +115,10 @@ let
     ∇f = ∇(f)
     @test ∇f([5.0]) == ([0.0],)
     @test ∇f([6.0]) == ([3.0],)
+    f(x, y) = x ≈ y ? 2y : 3x
+    ∇f = ∇(f)
+    @test ∇f(5.0, 5.0) == (0.0, 2.0)
+    @test ∇f(6.0, 5.0) == (3.0, 0.0)
 end
 
 # Check that functions with extra, unused variables can be differentiated


### PR DESCRIPTION
With the current code we run into a method ambiguity error whenever we have `isapprox(n::Node, f::Node)`. This PR solves that.