### PR TITLE
Fix a very unlikely corner case for get_output

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -163,6 +163,13 @@ let
     @test (∇x, ∇y) == ∇f(x, y)
 end
 
+@testset "get_output" begin
+    y = ∇(-, get_output=true)(2)
+    @test y isa Tuple{Branch{Int}, Tuple{Int}}
+    @test last(y) == (-1,)
+    @test ∇(unbox, get_output=true)(2) == (2, (0,))
+end
+
 # Tests for zero'd and one'd containers.
 let
     import Nabla: zerod_container, oned_container


### PR DESCRIPTION
Currently, when passing the `get_output` keyword argument to `∇`, you only actually get the output if evaluating the function on the arguments converted to nodes returns a node. With this change, `get_output` always gives you the output of the function call, whether it's a node or not.