### PR TITLE
Remove REQUIRE, add version to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "Nabla"
 uuid = "49c96f43-aa6d-5a04-a506-44c7070ebe78"
+version = "0.11.0"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 1.0
-DualNumbers 0.6.0
-DiffRules 0.0.1
-FDM 0.1.0
-SpecialFunctions 0.5.0

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-Distributions
-BenchmarkTools 0.0.8


### PR DESCRIPTION
Package versions are now registered via Registrator rather than METADATA and Attobot, which means REQUIRE files are no longer needed and that versioning information is based on that declared in Project.toml files.