### PR TITLE
Fix FDM version bounds, bump Nabla version to 0.11.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nabla"
 uuid = "49c96f43-aa6d-5a04-a506-44c7070ebe78"
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
@@ -11,11 +11,11 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-DiffRules = "0.0"
-DualNumbers = "0.6.0"
-FDM = "0.1.0, 0.2.0"
+DiffRules = "^0.0"
+DualNumbers = ">=0.6.0"
+FDM = ">=0.1.0"
 SpecialFunctions = ">=0.5.0"
-julia = "1.0"
+julia = "^1.0"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
Currently FDM's version is restricted to 0.1.0 or 0.2.0, which doesn't really make sense; any version of FDM since 0.1.0 should be fully compatible with Nabla. Imposing the version restriction makes later versions of FDM uninstallable in the global environment if Nabla was installed first.

This change sets FDM to have a lower bound only, it frees DualNumbers to have a lower bound only rather than a fixed version, it adds an explicit caret to the Julia bound (non-functional change as carets are implicit), and it sets Nabla's own version to 0.11.1 in preparation for a new tag.