### PR TITLE
Allow working with Refs

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -256,6 +256,7 @@ for (f_name, scalar_init, array_init) in
             end
             return y
         end
+        $f_name(x::Ref) = Ref($f_name(x[]))
     end)
 end
 @inline randned_container(x::Number) = randn(typeof(x))

--- a/test/core.jl
+++ b/test/core.jl
@@ -195,6 +195,9 @@ let
 
     @test zerod_container(Dict("a"=>5.0, "b"=>randn(3))) == Dict("a"=>0.0, "b"=>zeros(3))
     @test oned_container(Dict("a"=>5.0, "b"=>randn(3))) == Dict("a"=>1.0, "b"=>ones(3))
+
+    @test ref_equal(zerod_container(Ref(4)), Ref(0))
+    @test ref_equal(oned_container(Ref(4)), Ref(1))
 end
 
 # To ensure we end up using the fallback machinery for ∇(x̄, f, ...) we'll define a new

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,10 @@ using Distributions, BenchmarkTools, SpecialFunctions, DualNumbers
 
 using Nabla: unbox, pos, tape, oneslike, zeroslike
 
+# Helper function for comparing `Ref`s, since they don't compare equal under `==`
+ref_equal(a::Ref{T}, b::Ref{T}) where {T} = a[] == b[]
+ref_equal(a::Ref, b::Ref) = false
+
 @testset "Core" begin
     include("core.jl")
     include("code_transformation/util.jl")

--- a/test/sensitivities/indexing.jl
+++ b/test/sensitivities/indexing.jl
@@ -19,4 +19,8 @@
         @test unbox(y) == [10, 10, 10]
         @test ∇(y, oneslike(unbox(y)))[x] == [0, 1, 2]
     end
+
+    @testset "Ref" begin
+        @test ref_equal(∇(getindex)(Ref(4))[1], Ref(1))
+    end
 end


### PR DESCRIPTION
The existing sensitivity definition for `getindex` is generic enough to work for `Ref`s out of the box. We just need to define the zero- and one-dimensional container functions for `Ref`s.