### PR TITLE
Refactor SVD and getproperty sensitivities to use U, S, and V

### DIFF
--- a/test/sensitivities/linalg/factorization/svd.jl
+++ b/test/sensitivities/linalg/factorization/svd.jl
@@ -43,4 +43,14 @@
         @test Nabla.eyesubx!(copy(X)) ≈ I - X
         @test Nabla.add!(copy(X), Y) ≈ X + Y
     end
+
+    @testset "Tape updating from multiple components" begin
+        ∇f = ∇() do X
+            U, S, V = svd(X)
+            Y = U * Diagonal(S) * V'
+            sum(Y)
+        end
+        X = [1.0 2.0; 3.0 4.0; 5.0 6.0]
+        @test ∇f(X)[1] ≈ ones(3, 2) atol=1e-5
+    end
 end


### PR DESCRIPTION
Consider a computation which uses multiple fields of `svd(X)`. The forward graph looks like:
```
  F = svd(X)
    /|\
   / | \
F.U F.S F.V
```
When we perform the reverse pass, traversing this graph back upward, `F.U`, `F.S`, and `F.V` will try to update the sensitivity for the initial `svd` call. That means we'll be updating with multiple, potentially nonzero values passed to `∇(svd, ...)` at once in order to properly update. The current machinery does not allow for that; instead, we try to update the `svd` sensitivity one component at a time, which can cause dimensionality issues when `X` and its SVD components have different sizes.

To fix this, we'll have `∇(getproperty, ...)` return a `NamedTuple` with `U`, `S`, and `V` fields, one of which will be populated with the incoming sensitivity, which corresponds to one of these fields, and the rest of them are set to zero. Then, when we go to update this `NamedTuple`-based sensitivity, we simply update the relevant component. Then, when `∇(svd, ...)` receives a `NamedTuple`, it will have all of the information it needs to update.