### PR TITLE
Allow ±1 allocation

### DIFF
--- a/test/sensitivities/functional/functional.jl
+++ b/test/sensitivities/functional/functional.jl
@@ -234,8 +234,8 @@ using DiffRules: diffrule, hasdiffrule
         let
             @eval foo_small() = sum($f(tanh, Leaf(Tape(), randn(10, 10))))
             @eval foo_large() = sum($f(tanh, Leaf(Tape(), randn(10, 100))))
-            @test allocs(@benchmark foo_small()) == allocs(@benchmark foo_large())
-            @test allocs(@benchmark ∇(foo_small())) == allocs(@benchmark ∇(foo_large()))
+            @test allocs(@benchmark foo_small()) ≈ allocs(@benchmark foo_large()) atol=1
+            @test allocs(@benchmark ∇(foo_small())) ≈ allocs(@benchmark ∇(foo_large())) atol=1
         end
     end
 


### PR DESCRIPTION
- Allocations changed in Julia v1.5
- Closes #185 
- since we're just testing that the number of allocations isn't proportional to the size of the inputs, i think a bit of leeway is fine