### PR TITLE
Drop 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nabla"
 uuid = "49c96f43-aa6d-5a04-a506-44c7070ebe78"
-version = "0.12.1"
+version = "0.13.0"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
@@ -15,7 +15,7 @@ DiffRules = "^0.0"
 DualNumbers = ">=0.6.0"
 FDM = "^0.6"
 SpecialFunctions = ">=0.5.0"
-julia = "^1.0"
+julia = "^1.3"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nabla"
 uuid = "49c96f43-aa6d-5a04-a506-44c7070ebe78"
-version = "0.13.0"
+version = "0.12.2"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"


### PR DESCRIPTION
Context on why we're dropping 1.0.

This links to the Invenia slack channels, so only people with access will be able to see it.
https://invenia.slack.com/archives/C0259AJLE/p1607448687325200

I believe the consensus is that while using Julia 1.0 we can only use `SpecialFunctions.jl` up to version `0.8.0`, and that version causes a stack overflow in the tests. Newer versions of `SpecialFunctions.jl` exist but can only be used for newer versions of Julia.