### PR TITLE
Fix compat ranges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,9 +12,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 DiffRules = "^0.0"
-DualNumbers = ">=0.6.0"
+DualNumbers = "0.6"
 FDM = "^0.6"
-SpecialFunctions = ">=0.5.0"
+SpecialFunctions = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 1"
 julia = "^1.3"
 
 [extras]


### PR DESCRIPTION
Registry is mad about `DualNumbers` and `SpecialFunctions` not having upper bounds. https://github.com/JuliaRegistries/General/pull/26253

This attempts to fix that