### PR TITLE
Narrowed down the minimum changes needed to get CI passing again

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nabla"
 uuid = "49c96f43-aa6d-5a04-a506-44c7070ebe78"
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
@@ -15,7 +15,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ChainRules = "0.8, 1"
+ChainRules = "0.8, 1.35.3"
 ChainRulesCore = "0.10.9, 1"
 ChainRulesOverloadGeneration = "0.1.2"
 ExprTools = "0.1.4"

--- a/src/sensitivities/chainrules.jl
+++ b/src/sensitivities/chainrules.jl
@@ -196,7 +196,7 @@ function overload_declarations!(signature_def)
     definitions = Expr[]
     for swap_mask in Iterators.product(ntuple(_->(true, false), n_args)...)
         any(swap_mask) || continue  # don't generate if not swapping anything.
-        
+
         # Also don't generate if swapping only final varadic argument
         # as this could be a emptry varadic argument and thus result in type-pirating
         # original function.

--- a/src/sensitivities/linalg/factorization/cholesky.jl
+++ b/src/sensitivities/linalg/factorization/cholesky.jl
@@ -9,12 +9,12 @@ const AM = AbstractMatrix
 const UT = UpperTriangular
 
 
-
 @explicit_intercepts(
     Cholesky,
     Tuple{AbstractMatrix{<:∇Scalar}, Union{Char, Symbol}, Integer},
     [true, false, false],
 )
+
 function ∇(
     ::Type{Cholesky},
     ::Type{Arg{1}},
@@ -40,4 +40,20 @@ function ∇(
     info::Integer,
 )
     return getproperty(X̄, Symbol(uplo))
+end
+
+# Yar, some work arounds for breaking changes in ChainRules.jl
+# https://github.com/JuliaDiff/ChainRules.jl/pull/630
+
+# Single arg function was dropped
+function ChainRules.rrule(::typeof(cholesky), A::AbstractMatrix{<:Real})
+    return ChainRules.rrule(cholesky, A, Val(false))
+end
+
+# U and L properties were replaced with factors
+# This should probably be moved to ChainRules to support both options.
+function Base.getproperty(tangent::Tangent{P, T}, sym::Symbol) where {P <: Cholesky, T <: NamedTuple}
+    idx = hasfield(T, :factors) && sym in (:U, :L) ? :factors : sym
+    hasfield(T, idx) || return ZeroTangent()
+    return unthunk(getfield(ChainRulesCore.backing(tangent), idx))
 end

--- a/test/sensitivities/linalg/factorization/cholesky.jl
+++ b/test/sensitivities/linalg/factorization/cholesky.jl
@@ -19,7 +19,8 @@
         @test getfield(U, :f) == Base.getproperty
         @test unbox(U) ≈ cholesky(X_).U
 
-        @test_throws MethodError ∇(X->cholesky(X).info)(X_)
+        # @test_throws MethodError ∇(X->cholesky(X).info)(X_)
+        @test_throws ErrorException ∇(X->cholesky(X).info)(X_)
     end
 
     let


### PR DESCRIPTION
I don't type piracy is the right solution here, but it narrows down the specific changes that broke our codebase. Perhaps we should re-add these methods to ChainRules?