### PR TITLE
Fix kwargs.data deprecation (since Julia 1.7)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nabla"
 uuid = "49c96f43-aa6d-5a04-a506-44c7070ebe78"
-version = "0.12.3"
+version = "0.12.4"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"

--- a/src/core.jl
+++ b/src/core.jl
@@ -80,7 +80,9 @@ struct Branch{T} <: Node{T}
 end
 function Branch(f, args::Tuple, tape::Tape; kwargs...)
     unboxed = unbox.(args)
-    branch = Branch(f(unboxed...; kwargs...), f, args, kwargs.data, tape, length(tape) + 1)
+    branch = Branch(
+        f(unboxed...; kwargs...), f, args, getfield(kwargs, :data), tape, length(tape) + 1
+    )
     push!(tape, branch)
     return branch
 end


### PR DESCRIPTION
Removes depwarn introduced by https://github.com/JuliaLang/julia/pull/39448

Should have no effect on correctness for Julia 1.8 and below; Julia wants us to use `keys` and `values` for accessing `kwargs` elements but those might have performance impacts. Likely this version of Nabla will not be used on future versions of Julia. 